### PR TITLE
leetcode 185. Department Top Three Salaries Advanced select & Bun update

### DIFF
--- a/SQL/Leetcode/Advanced select/185. Department Top Three Salaries/gpt/DepartmentTopThreeSalaries_mysql.md
+++ b/SQL/Leetcode/Advanced select/185. Department Top Three Salaries/gpt/DepartmentTopThreeSalaries_mysql.md
@@ -1,0 +1,254 @@
+# 解法（MySQL）
+
+## 1) 最適解（単一クエリ：ウィンドウ関数 / DENSE_RANK）
+
+```sql
+SELECT
+  d.name  AS Department,
+  e.name  AS Employee,
+  e.salary AS Salary
+FROM (
+  SELECT
+    id, name, salary, departmentId,
+    DENSE_RANK() OVER (
+      PARTITION BY departmentId
+      ORDER BY salary DESC
+    ) AS rnk
+  FROM Employee
+) AS e
+JOIN Department AS d
+  ON d.id = e.departmentId
+WHERE e.rnk <= 3;
+
+-- Runtime 1048 ms
+-- Beats 42.08%
+```
+
+- **ポイント**：`DENSE_RANK()` は同一給与のタイを同順位にするため、「上位 3 つの**ユニーク**給与」を正しく表現できます。
+
+---
+
+## 2) 代替解（相関サブクエリ / DISTINCT カウント）
+
+```sql
+SELECT
+  d.name  AS Department,
+  e.name  AS Employee,
+  e.salary AS Salary
+FROM Employee AS e
+JOIN Department AS d
+  ON d.id = e.departmentId
+WHERE (
+  SELECT COUNT(DISTINCT e2.salary)
+  FROM Employee AS e2
+  WHERE e2.departmentId = e.departmentId
+    AND e2.salary > e.salary
+) < 3;
+
+-- Runtime 1152 ms
+-- Beats 34.15%
+```
+
+- **注意点**：
+
+  - `COUNT(DISTINCT ...)` により「上の**ユニーク**給与数」が 0,1,2 の人だけを残します（=上位 3 つ以内）。
+  - `NOT IN` は **NULL 罠**があるため不採用（要件にも準拠）。
+
+---
+
+## 3) 要点解説
+
+- **採用理由**
+
+  - 最適解：`DENSE_RANK()` は「ユニーク順位」→ タイがあっても 1 位, 2 位, 3 位の**3 つの給与水準**を正しく切り出せる。MySQL 8 のウィンドウ関数で **可読性・拡張性・速度**のバランスが良い。
+  - 代替解：ウィンドウ関数が使えない環境でも動く。`COUNT(DISTINCT salary)` を使うことでユニーク性を担保。
+
+- **エッジケース**
+
+  - 部門内のユニーク給与が 1〜2 個しかない：`DENSE_RANK <= 3` でも自然に該当行のみ出力。
+  - タイブレーク（同一給与複数人）：**全員**が対象（問題仕様通り）。
+  - `NULL` 給与は本問題のデータ設計上通常想定しないが、存在すると `DENSE_RANK` は最後尾に降順並び。代替解でも `> e.salary` 条件により影響は限定的。
+  - 表示列・並び順：出力順は任意、列名は指定に合わせて投影済み。
+
+---
+
+## 4) 計算量（概算）
+
+- **最適解（ウィンドウ関数）**：
+
+  - パーティション（部門）ごとに並べ替え：概ね `O(N log N)`（N=Employee 行数）。
+  - 適切なインデックス（例：`Employee(departmentId, salary DESC)`、`Department(id)`）があると実務では I/O を削減。
+
+- **代替解（相関）**：
+
+  - 天然だと各行に対して同部門をスキャン → 最悪 `O(N^2)`。
+  - `Employee(departmentId, salary)` の複合インデックスでサブクエリが範囲探索になり大幅改善（実効は `O(N log N)` 近辺）。
+
+---
+
+## 5) 図解（Mermaid 超保守版）
+
+```mermaid
+flowchart TD
+  A[入力テーブル Employee と Department]
+  B[部門で結合 Department.id = Employee.departmentId]
+  C[部門ごとに順位付け DENSE RANK で salary を降順]
+  D[順位 rnk が 3 以下を抽出]
+  E[出力 Department Employee Salary]
+  A --> B
+  B --> C
+  C --> D
+  D --> E
+```
+
+---
+
+必要に応じて、実データ量・索引状況に合わせた `EXPLAIN ANALYZE` の読み方やインデックス提案もできます。
+
+1048ms/1152ms だとまだ伸びしろあります。主なボトルネックは「部門ごとに**全行**へウィンドウ関数をかけてソート」している点です。
+以下の順で効きます。
+
+---
+
+## 1) まずはクエリ自体を軽くする（重複給与を先に除去）
+
+「ユニーク給与の上位 3 つ」が欲しいだけなので、**先に `(departmentId, salary)` を DISTINCT** してから `DENSE_RANK()` を当てると、ソート対象が小さくなります（同給与が多い部門で特に効く）。
+
+### 改善版（推奨：ウィンドウ関数 × 事前重複除去）
+
+```sql
+WITH uniq AS (
+  SELECT DISTINCT departmentId, salary
+  FROM Employee
+),
+top3 AS (
+  SELECT
+    departmentId,
+    salary,
+    DENSE_RANK() OVER (
+      PARTITION BY departmentId
+      ORDER BY salary DESC
+    ) AS rnk
+  FROM uniq
+)
+SELECT
+  d.name AS Department,
+  e.name AS Employee,
+  e.salary AS Salary
+FROM top3 t
+JOIN Employee e
+  ON e.departmentId = t.departmentId
+ AND e.salary       = t.salary
+JOIN Department d
+  ON d.id = e.departmentId
+WHERE t.rnk <= 3;
+
+-- Runtime 765 ms
+-- Beats 99.03%
+```
+
+### **狙い**
+
+- ウィンドウ関数が処理する行数を `N → 部門×(ユニーク給与数)` に削減。
+- その後にだけ Employee と突合（=最小限の結合）。
+
+---
+
+## 2) 代替：相関で「上位 3 つのユニーク給与」に属するかだけ判定
+
+MySQL 8 ではサブクエリに `LIMIT` を使えるので、「部門ごとの上位 3 給与サブセット」に属するかを **EXISTS** で判定する案。実装は短く、インデックスが効けば速いケースもあります。
+
+```sql
+SELECT
+  d.name  AS Department,
+  e.name  AS Employee,
+  e.salary AS Salary
+FROM Employee e
+JOIN Department d
+  ON d.id = e.departmentId
+WHERE EXISTS (
+  SELECT 1
+  FROM (
+    SELECT DISTINCT e2.salary
+    FROM Employee e2
+    WHERE e2.departmentId = e.departmentId
+    ORDER BY e2.salary DESC
+    LIMIT 3
+  ) AS top3
+  WHERE top3.salary = e.salary
+);
+
+-- Runtime 1159 ms
+-- Beats 33.72%
+```
+
+### **注意**
+
+- Optimizer が「外側の行ごとに内側を毎回作る」戦略を取ると遅くなり得ます。行数が多いときは 1) 案に軍配。
+
+---
+
+## 3) インデックス最適化（最重要）
+
+LeetCode 環境では CREATE INDEX が使えないことが多いですが、**実務/ローカル検証では効果絶大**です。
+
+### ウィンドウ関数案（1) を速くする索引
+
+```sql
+-- ウィンドウの分割＆並びに合致
+CREATE INDEX idx_emp_dept_salary_id ON Employee(departmentId, salary DESC, id);
+
+-- 参照側
+CREATE INDEX idx_dept_id ON Department(id);
+```
+
+- `departmentId, salary` でパーティションソートを助け、
+- その後の `JOIN e.departmentId = t.departmentId AND e.salary = t.salary` を**索引結合**に寄せやすくします。
+- 可能なら **カバリング**（`..., name` まで含める）でテーブルアクセス削減：
+
+  ```sql
+  CREATE INDEX idx_emp_cover ON Employee(departmentId, salary DESC, id, name);
+  ```
+
+### 相関 EXISTS 案（2) を速くする索引
+
+```sql
+-- WHERE e2.departmentId = ? AND ORDER BY e2.salary DESC の範囲探索を最適化
+CREATE INDEX idx_emp_dept_salary ON Employee(departmentId, salary DESC);
+```
+
+---
+
+## 4) さらに詰める小技
+
+- **投影の最小化**：ウィンドウ関数・ソート段階では `departmentId, salary` だけ扱い、`name` は最後に結合（上の 1) は既にそうなっています）。
+- **不要な ORDER BY を外す**：結果順は任意なので付けない。
+- **集計方向の一致**：降順のため `salary DESC` をインデックス定義でも DESC にしておく（MySQL 8 は昇降混在索引を利用可能）。
+- **超大規模時の分割**：部門が非常に多い＆偏っているなら、一時テーブルに `uniq` を落としてから `top3` を作るとメモリ消費の安定に効くことがあります。
+
+  ```sql
+  CREATE TEMPORARY TABLE uniq (INDEX(departmentId, salary))
+  AS SELECT DISTINCT departmentId, salary FROM Employee;
+  ```
+
+---
+
+## 5) 期待できる効果（概算）
+
+- **1) 改善版**：
+
+  - もとの `DENSE_RANK` は各部門で N 行に対し `O(N log N)` 的にソート。
+  - `DISTINCT` 後は **ユニーク給与数 U**（U≪N が多い）に対するソートに変わり、体感で 20–60% 改善するケースが多いです。
+
+- **2) EXISTS**：
+
+  - インデックス化されていれば「外側 1 行あたり上位 3 件の距離だけ」走るため、分布次第で速い。
+  - ただし Optimizer 次第で再実行が多いと伸びづらい。
+
+---
+
+## 6) まとめ（まずはこれを試す）
+
+1. の **「先に DISTINCT → DENSE_RANK → join 返し」** に置き換え。
+   LeetCode でもこれだけで多くのケースで Runtime が改善します。
+   実務ではあわせて **`Employee(departmentId, salary DESC, id[, name])`** の複合インデックスを用意すると、さらに大きく短縮できます。

--- a/SQL/Leetcode/Advanced select/185. Department Top Three Salaries/gpt/DepartmentTopThreeSalaries_pandas.md
+++ b/SQL/Leetcode/Advanced select/185. Department Top Three Salaries/gpt/DepartmentTopThreeSalaries_pandas.md
@@ -1,0 +1,234 @@
+# 解法（Pandas）
+
+## 1) 実装（指定シグネチャ厳守）
+
+```python
+import pandas as pd
+
+def department_top_three_salaries(employee: pd.DataFrame, department: pd.DataFrame) -> pd.DataFrame:
+    """
+    Returns:
+        pd.DataFrame: 列名・順序は ['Department', 'Employee', 'Salary']
+    """
+    # 1) (departmentId, salary) をユニーク化してから部門内で DENSE RANK（降順）
+    uniq = (
+        employee.loc[:, ['departmentId', 'salary']]
+        .drop_duplicates(ignore_index=True)
+    )
+    uniq['rnk'] = (
+        uniq.groupby('departmentId')['salary']
+            .rank(method='dense', ascending=False)
+    )
+
+    # 2) 上位3つのユニーク給与だけに絞る
+    top3 = uniq.loc[uniq['rnk'] <= 3, ['departmentId', 'salary']]
+
+    # 3) 対象給与に属する従業員を突合
+    hit = employee.merge(
+        top3,
+        on=['departmentId', 'salary'],
+        how='inner'
+    )
+
+    # 4) 部門名を付与し、仕様列のみ投影
+    out = (
+        hit.merge(department, left_on='departmentId', right_on='id', how='inner')
+           .loc[:, ['name_y', 'name_x', 'salary']]
+           .rename(columns={'name_y': 'Department', 'name_x': 'Employee', 'salary': 'Salary'})
+    )
+
+    # 返却（順序任意のためソート不要。型は元データに従う）
+    return out
+```
+
+---
+
+## 2) アルゴリズム説明
+
+- **ユニーク給与の事前抽出**：`employee[['departmentId','salary']].drop_duplicates()`
+  同額タイが多いほど、以降の処理量（ランキング用の並べ替え対象）が小さくなり高速化します。
+- **ユニーク順位（DENSE RANK）**：`groupby(... )['salary'].rank(method='dense', ascending=False)`
+  給与タイは同順位になるため、「上位 3 つの**ユニーク**給与」という要件に一致。
+- **上位 3 に属する従業員の抽出**：`employee` と `top3` を `(departmentId, salary)` で `merge`。
+  「給与水準に属する全員」を拾える（タイの全員を返す）。
+- **部門名の付与**：`department` と結合して部門名を投影。
+  出力は **['Department', 'Employee', 'Salary']** の順で返す。
+
+### NULL / 重複 / 型の扱い
+
+- `salary` が `NaN` の場合：降順ランクでは末尾扱いになり、通常は上位 3 に含まれません（仕様的に問題なし）。
+- 従業員の重複行は前提的に存在しないが、抽出は **(departmentId, salary)** 基準で行うため、同額タイは**全員**が残ります。
+- 型変換は不要（入力の `int` / `string` をそのまま返す）。Pandas の `rank()` は float を返すが、`rnk` 列は最終出力に含めません。
+
+---
+
+## 3) 計算量（概算）
+
+- `drop_duplicates`：概ね **O(N)**（ハッシュベース）。
+- `groupby.rank`（ユニーク集合に対して）：部門ごとに **O(U_d log U_d)** の並べ替え相当（実効は実装依存だが概ね線形～準線形）。
+- 2 回の `merge`：それぞれ **O(N)** 程度（ハッシュ結合想定、一時メモリを消費）。
+- 合算のオーダ感：**O(N + Σ U_d log U_d)**。同額タイが多いほど `U_d ≪ n_d` になり速くなります。
+- **メモリ**：`uniq` と `top3` の中間生成分が増えるため、大規模データでは列最小化（本実装は必要列のみ）と適宜 `astype` で圧縮を。
+
+---
+
+## 4) 図解（Mermaid 超保守版）
+
+```mermaid
+flowchart TD
+  A[Input DataFrames Employee Department]
+  B[Drop duplicates by departmentId salary]
+  C[Dense rank per department desc]
+  D[Filter rnk <= 3]
+  E[Merge with Employee then Department]
+  F[Return Department Employee Salary]
+  A --> B
+  B --> C
+  C --> D
+  D --> E
+  E --> F
+```
+
+必要に応じて、`groupby.head` ベースの実装や `nlargest` / `aggregate` を絡めた別解、
+メモリ節約のためのカテゴリ型化（`departmentId`/`name` を `category`化）なども提案できます。
+
+**365 ms (Beats 52.25%) / Memory 69.72 MB (Beats 12.92%)** はまだ伸ばせます。
+Pandas では「中間表の削減」と「merge→map 化」でだいぶ詰められます。
+
+---
+
+## 1) 改訂版（推奨）— `drop_duplicates` と 2 回の `merge` を廃止
+
+- 直接 **部門内で `DENSE RANK`（降順）を各行に付与**し、`rnk <= 3` の行だけ残す
+  → “ユニーク給与”という要件も **`rank(method="dense")`** で満たせます（同額は同順位）。
+- `Department` との結合は **`map`**（辞書引き）で置換
+  → DataFrame-merge より軽量で速いことが多い。
+
+```python
+import pandas as pd
+
+def department_top_three_salaries(employee: pd.DataFrame, department: pd.DataFrame) -> pd.DataFrame:
+    """
+    Returns:
+        pd.DataFrame: 列名・順序は ['Department', 'Employee', 'Salary']
+    """
+    # 1) 部門内でのユニーク順位（降順）。同額は同順位＝ユニーク給与順位
+    rnk = employee.groupby('departmentId')['salary'].rank(method='dense', ascending=False)
+
+    # 2) 上位3位以内だけを残す（不要列は持ち越さない）
+    hit = employee.loc[rnk <= 3, ['departmentId', 'name', 'salary']]
+
+    # 3) 部門名はマップで付与（DataFrame merge より軽量）
+    dept_map = department.set_index('id')['name']
+
+    out = pd.DataFrame({
+        'Department': hit['departmentId'].map(dept_map),
+        'Employee': hit['name'],
+        'Salary':    hit['salary'],
+    })
+
+    return out
+
+# Analyze Complexity
+
+# Runtime 315 ms
+# Beats 96.22%
+# Memory 68.76 MB
+# Beats 94.72%
+
+```
+
+### ここが速い理由
+
+- **`drop_duplicates` をやめる**：全件を一度ハッシュ化してユニークにするコストと追加メモリを削減。
+- **`merge`×2 → `map`×1**：結合キーが単一（`departmentId`→`id`）なら `map` の方が軽い。
+- **列の最小化**：`hit` は必要列だけ持ち回る。コピー・材料サイズを抑制。
+
+---
+
+## 2) 追加の代替案（ワークロード次第で有効）
+
+### 2-1) 「超大規模・同額が極端に多い」ケース向け（ユニーク先行）
+
+“明らかに” 同額が多いなら、ユニーク化 → ランク → 内結合も検討余地あり（以前の案）。
+ただし通常は上記「推奨版」の方が総合的に速いことが多いです。
+
+```python
+def department_top_three_salaries_distinct_first(employee: pd.DataFrame, department: pd.DataFrame) -> pd.DataFrame:
+    uniq = employee[['departmentId', 'salary']].drop_duplicates(ignore_index=True)
+    uniq['rnk'] = uniq.groupby('departmentId')['salary'].rank(method='dense', ascending=False)
+    top3 = uniq.loc[uniq['rnk'] <= 3, ['departmentId', 'salary']]
+
+    hit = employee.merge(top3, on=['departmentId', 'salary'], how='inner')[['departmentId', 'name', 'salary']]
+    dept_map = department.set_index('id')['name']
+    return pd.DataFrame({
+        'Department': hit['departmentId'].map(dept_map),
+        'Employee': hit['name'],
+        'Salary': hit['salary'],
+    })
+
+# Analyze Complexity
+
+# Runtime 345 ms
+# Beats 70.37%
+# Memory 69.93 MB
+# Beats 7.33%
+```
+
+### 2-2) メモリ圧縮の小技（必要なときだけ）
+
+- `departmentId` が広い範囲の `int64` でないなら一時的に `Int32` 化
+- `Employee` / `Department` の `name` を `category` 化
+  → **返却前に元 dtype に戻す必要はなし**（LeetCode は object で通ることが多いが、環境により差があるため本体実装では敢えて触れていません）。
+  ※ 隠れテストへの影響が怖い場合は本体には入れず、検証用にのみ適用してください。
+
+---
+
+## 3) アルゴリズム説明（推奨版）
+
+- `groupby('departmentId')['salary'].rank(method='dense', ascending=False)`
+  各部門ごとに給与を降順でユニーク順位化。
+- `rnk <= 3` でフィルタ
+  → 「上位 3 つのユニーク給与」層に属する従業員だけが残る（同額は全員残る）。
+- `department.set_index('id')['name']` を `map`
+  → キー → 値の辞書引きで部門名を付与。
+- 余計な `sort_values` や print は行わない（要件準拠、速度面でも有利）。
+
+### NULL・重複・型の扱い
+
+- `salary` が `NaN`：降順ランクでは末尾になるため通常は `rnk<=3` に入らない。
+- 同額タイ：`dense` により同順位扱い → 要件通り全員を返す。
+- 出力列は `['Department', 'Employee', 'Salary']`。順序指定、余計な列は返さない。
+
+---
+
+## 4) 計算量（概算）２
+
+- `groupby.rank`：部門ごとに並べ替え相当（実装最適化あり）。概ね **O(N log n_d)** を部門で合算（経験的にはほぼ **O(N)** に近い速度）。
+- `map`：**O(N)**。
+- 合計：**O(N)** ～ **O(N log n_d)** 近辺。
+- メモリ：中間の `rnk`（`float64`）1 列分 + `hit` 部分行。`merge` をやめたことでピークを下げやすい。
+
+---
+
+## 5) 図解（Mermaid 超保守版・日本語）
+
+```mermaid
+flowchart TD
+  A[入力 Employee と Department]
+  B[部門内で給与を降順で順位付け DENSE RANK]
+  C[順位 rnk が3以下を抽出]
+  D[departmentIdを部門名にマップ]
+  E[Department Employee Salary の順で返す]
+  A --> B
+  B --> C
+  C --> D
+  D --> E
+```
+
+---
+
+### まとめ
+
+- **`rank(dense)` を各行に直接当てて `map` で部門名付与**が、Pandas では一番バランス良く速い構成になりやすいです。
+- さらに詰めたければ、入力側で `name` を `category` 化／`departmentId` のビット幅最適化を検証（隠れテストへの影響がない範囲で）。

--- a/SQL/Leetcode/Advanced select/185. Department Top Three Salaries/gpt/DepartmentTopThreeSalaries_posgre.md
+++ b/SQL/Leetcode/Advanced select/185. Department Top Three Salaries/gpt/DepartmentTopThreeSalaries_posgre.md
@@ -1,0 +1,200 @@
+# 解法（PosgreSQL）
+
+## 1) 最適解（単一クエリ：CTE で重複給与を先に除去 → DENSE_RANK）
+
+```sql
+WITH uniq AS (
+  SELECT DISTINCT departmentId, salary
+  FROM Employee
+),
+top3 AS (
+  SELECT
+    departmentId,
+    salary,
+    DENSE_RANK() OVER (
+      PARTITION BY departmentId
+      ORDER BY salary DESC
+    ) AS rnk
+  FROM uniq
+)
+SELECT
+  d.name AS "Department",
+  e.name AS "Employee",
+  e.salary AS "Salary"
+FROM top3 t
+JOIN Employee e
+  ON e.departmentId = t.departmentId
+ AND e.salary       = t.salary
+JOIN Department d
+  ON d.id = e.departmentId
+WHERE t.rnk <= 3;
+
+-- Analyze Complexity
+-- Runtime 236 ms
+-- Beats 96.42%
+
+-- Memory 0.00 MB
+-- Beats 100.00%
+```
+
+**狙い**：まず `(departmentId, salary)` をユニークにしてから順位付け ⇒ ソート対象が減り、高速化しやすい（同額タイが多い部門で特に効く）。
+
+---
+
+## 2) 代替解
+
+### 2-1) LATERAL × DISTINCT × LIMIT で「部門ごとの上位 3 給与」を作って突合
+
+```sql
+SELECT
+  d.name AS "Department",
+  e.name AS "Employee",
+  e.salary AS "Salary"
+FROM Department d
+JOIN LATERAL (
+  SELECT DISTINCT e2.salary
+  FROM Employee e2
+  WHERE e2.departmentId = d.id
+  ORDER BY e2.salary DESC
+  LIMIT 3
+) s ON TRUE
+JOIN Employee e
+  ON e.departmentId = d.id
+ AND e.salary       = s.salary;
+
+-- Analyze Complexity
+-- Runtim 249 ms
+-- Beats 76.86%
+
+-- Memory 0.00 MB
+-- Beats 100.00%
+```
+
+- **長所**：部門ごとに **上位 3 のユニーク給与**だけを算出してから従業員を結合。`(departmentId, salary DESC)` インデックスが効くと速い。
+- **短所**：部門数が非常に多く、各部門に従業員が大量だと、LATERAL が部門ごとにサブ計算するため、分布次第でプランがブレることがある。
+
+### 2-2) 直球：ウィンドウを全件に当てる（実装は短い）
+
+```sql
+SELECT
+  d.name AS "Department",
+  e.name AS "Employee",
+  e.salary AS "Salary"
+FROM (
+  SELECT
+    id, name, salary, departmentId,
+    DENSE_RANK() OVER (
+      PARTITION BY departmentId
+      ORDER BY salary DESC
+    ) AS rnk
+  FROM Employee
+) e
+JOIN Department d
+  ON d.id = e.departmentId
+WHERE e.rnk <= 3;
+
+-- Analyze Complexity
+
+-- Runtime 257 ms
+-- Beats 66.85%
+-- Memory 0.00 MB
+-- Beats 100.00%
+
+```
+
+- **長所**：簡潔。
+- **短所**：ユニーク化せずに順位付けするため、**全行**を並べ替える。タイが多いほど無駄が増え、最適解より遅くなりやすい。
+
+### 2-3) 配列集約で上位 3 のユニーク給与を作って半結合
+
+```sql
+WITH s AS (
+  SELECT
+    departmentId,
+    (ARRAY_AGG(DISTINCT salary ORDER BY salary DESC))[1:3] AS top3
+  FROM Employee
+  GROUP BY departmentId
+)
+SELECT
+  d.name AS "Department",
+  e.name AS "Employee",
+  e.salary AS "Salary"
+FROM s
+JOIN Employee e
+  ON e.departmentId = s.departmentId
+ AND e.salary = ANY(s.top3)
+JOIN Department d
+  ON d.id = e.departmentId;
+
+-- Analyze Complexity
+
+-- Runtime 249 ms
+-- Beats 76.86%
+-- Memory 0.00 MB
+-- Beats 100.00%
+
+```
+
+- **長所**：部門単位でユニーク化と上位 3 抽出を一発で実現。読みやすい。
+- **短所**：`ARRAY_AGG(DISTINCT ...)` はメモリ使用量が増えやすい。極端にスキューした部門では要注意。
+
+---
+
+## 3) 要点解説
+
+- **PostgreSQL 流の表現**
+
+  - 過剰な `DISTINCT ON` は使わず、**必要な箇所だけユニーク化**（最適解の `uniq`）→ `DENSE_RANK`。
+  - LATERAL は「部門単位で少量だけ取りたい」時に有効（2-1）。
+  - 配列・`ANY` はセミジョイン代替としてスッキリ書ける（2-3）。
+
+- **NULL / 重複 / タイブレーク**
+
+  - `salary` が NULL の場合：`ORDER BY salary DESC` では NULL は最後尾（デフォルト）。上位 3 には通常含まれない。
+  - **重複給与**：`DENSE_RANK` により同順位扱い。上位 3**ユニーク給与**に属する全員を返すため仕様に一致。
+  - 判定は **ID 基準**だが、抽出条件は「給与水準 ∈ 上位 3（ユニーク）」で行い、投影列は仕様準拠（部門名・社員名・給与）。
+
+- **インデックス最適化（実務で強力）**
+
+  ```sql
+  -- 部門・給与の探索と並びに合致
+  CREATE INDEX ON Employee (departmentId, salary DESC) INCLUDE (name, id);
+  CREATE INDEX ON Department (id);
+  ```
+
+  - INCLUDE で**カバリング**度を上げ、テーブルアクセスを減らす（PostgreSQL 11+）。
+
+---
+
+## 5) 計算量（概算）
+
+- **最適解（CTE でユニーク → DENSE_RANK）**
+
+  - ユニーク化：部門ごとユニーク給与数を **U** とすると、並べ替えは概ね `O(U log U)` を部門分。
+  - 全体では `O(N)`（ハッシュ or インデックスでの重複除去）＋ `O(Σ U log U)`＋ 最終結合 `O(N)` 程度。
+  - 適切な索引で **Hash/Semi/Index Scan** が選ばれ、実務体感は `O(N+M)` 近似。
+
+- **3-2（全件ウィンドウ）**：各部門で `O(n_d log n_d)`（`n_d` は部門件数）。ユニーク化がない分、同額が多いと不利。
+- **3-1（LATERAL）**：各部門で `ORDER BY salary DESC LIMIT 3` の範囲探索。
+  `(departmentId, salary DESC)` 索引があれば実効は `O(#dept * log N + match)` 近辺。
+
+---
+
+## 6) 図解（Mermaid 超保守版）
+
+```mermaid
+flowchart TD
+  A[Input tables Employee Department]
+  B[Distinct departmentId salary]
+  C[Dense rank by departmentId salary desc]
+  D[Keep ranks 1 to 3]
+  E[Join back to Employee and Department]
+  F[Output Department Employee Salary]
+  A --> B
+  B --> C
+  C --> D
+  D --> E
+  E --> F
+```
+
+必要なら `EXPLAIN (ANALYZE, BUFFERS)` の読み解きとインデックスチューニング（並び順 DESC の利活用、付随列 INCLUDE の可否）まで掘り下げます。

--- a/bun.lock
+++ b/bun.lock
@@ -4,30 +4,30 @@
     "": {
       "name": "algorithm-study",
       "devDependencies": {
-        "@types/node": "^22.15.29",
-        "eslint": "^9.33.0",
+        "@types/node": "^22.18.10",
+        "eslint": "^9.37.0",
         "live-server": "^1.2.2",
       },
     },
   },
   "packages": {
-    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.7.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw=="],
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
 
     "@eslint/config-array": ["@eslint/config-array@0.21.0", "", { "dependencies": { "@eslint/object-schema": "^2.1.6", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ=="],
 
-    "@eslint/config-helpers": ["@eslint/config-helpers@0.3.1", "", {}, "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA=="],
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.0", "", { "dependencies": { "@eslint/core": "^0.16.0" } }, "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog=="],
 
-    "@eslint/core": ["@eslint/core@0.15.2", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg=="],
+    "@eslint/core": ["@eslint/core@0.16.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q=="],
 
     "@eslint/eslintrc": ["@eslint/eslintrc@3.3.1", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ=="],
 
-    "@eslint/js": ["@eslint/js@9.34.0", "", {}, "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw=="],
+    "@eslint/js": ["@eslint/js@9.37.0", "", {}, "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
-    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.5", "", { "dependencies": { "@eslint/core": "^0.15.2", "levn": "^0.4.1" } }, "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w=="],
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.0", "", { "dependencies": { "@eslint/core": "^0.16.0", "levn": "^0.4.1" } }, "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -41,7 +41,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@22.18.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ=="],
+    "@types/node": ["@types/node@22.18.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg=="],
 
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
@@ -145,7 +145,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.34.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.0", "@eslint/config-helpers": "^0.3.1", "@eslint/core": "^0.15.2", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.34.0", "@eslint/plugin-kit": "^0.3.5", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg=="],
+    "eslint": ["eslint@9.37.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.0", "@eslint/config-helpers": "^0.4.0", "@eslint/core": "^0.16.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.37.0", "@eslint/plugin-kit": "^0.4.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "version": "1.0.0",
     "type": "module",
     "devDependencies": {
-        "@types/node": "^22.15.29",
-        "eslint": "^9.33.0",
+        "@types/node": "^22.18.10",
+        "eslint": "^9.37.0",
         "live-server": "^1.2.2"
     }
 }


### PR DESCRIPTION
# 対応概要

* **問題テーマ**：「各部門の上位3つの**ユニーク**給与に属する従業員を取得」
* 対応対象：**MySQL 8**, **PostgreSQL 12+**, **Pandas（Python 3.11+ / pandas 2.x）**
* 付帯要件：**Mermaid 図解の安定描画（超保守版ルール）**、性能改善の提案

# 技術的対応（エンジン別）

* **MySQL 8**

  * 最適解：`(departmentId, salary)` を先に `DISTINCT` → `DENSE_RANK()` → `rnk <= 3` を従業員に結合
  * 代替解：`EXISTS` + サブクエリで `DISTINCT salary ORDER BY DESC LIMIT 3`
  * インデックス推奨：`Employee(departmentId, salary DESC[, id, name])`, `Department(id)`
* **PostgreSQL 12+**

  * 最適解：MySQL と同様に **CTEでユニーク化→DENSE_RANK→結合**
  * 代替解：`LATERAL` + `DISTINCT` + `LIMIT 3`、または配列集約 `ARRAY_AGG(DISTINCT ...)` + `ANY`
  * インデックス推奨：`Employee(departmentId, salary DESC) INCLUDE (name, id)`, `Department(id)`
* **Pandas**

  * 最適解：各行に直接 `groupby('departmentId')['salary'].rank(method='dense', ascending=False)` を付与→`rnk <= 3`
  * 結合は `map`（辞書引き）で部門名付与（`merge` より軽量）
  * 代替：ユニーク化→ランク→`merge` で所属回収（同額が極端に多い場合に有効）

# パフォーマンス改善（実測と施策）

* **MySQL**：`DISTINCT → DENSE_RANK → 結合` で大幅改善（あなたの計測で **765ms / Beats 99.03%** に上昇）
* **Pandas**：`drop_duplicates` と `merge×2` を排し、`rank` 直付け + `map` へ置換 ⇒ 中間表・メモリ削減（あなたの計測 **365ms / Beats 52.25%**）
* 共通の考え方：

  * 先にデータを**縮小**（ユニーク化や列最小化）
  * **ウィンドウ/ランキング**は必要最小限の集合に対して実施
  * 結合は**軽量手段**（`map` / `EXISTS` / 指定キーの結合）を優先
  * 結果順が任意なら**ORDER BYを付けない**

# Mermaid 図解（エラー原因と恒久対策）

* エラー原因：

  * ノード内の `\n` や `<br/>`、括弧 `()`、クォート `' " `、スラッシュ `/`、行末スペース、同一行に複数ノード等でパースが壊れる実装がある
* **超保守版ルール**（今後のテンプレートに反映）：

  * 記号を極力使わない（日本語＋英数字中心）
  * 各ノードは**1行**、行末スペースなし
  * ノードを同じ行に並べない
  * エッジ `A --> B` も1行ずつ
* 上記ルールで**MySQL / PostgreSQL / Pandas**の図解を修正・提供

# テンプレート提供

* **MySQL 8 / PostgreSQL 12+ / Pandas 2.x** それぞれに、汎用的に使える**Markdownテンプレート**を作成

  * 構成：前提 → 問題 → 最適解 → 代替解 → 要点解説 → 計算量 → Mermaid（超保守版）
  * プレースホルダー `{{...}}` を差し替えるだけで他問題にも再利用可能

# まとめ

* 解法は**ユニーク給与×ランキング**が核。
* パフォーマンスは「**前処理で縮小 → 最小コストの抽出 → 軽量結合**」で大きく改善。
* Mermaid は**超保守版**に統一してパースエラーを解消。
* 今後の作業の効率化のため、**エンジン別の汎用テンプレート**を整備済み。
