### PR TITLE
SQL: leetcode 511. Game Play Analysis I Basic Select

### DIFF
--- a/SQL/Leetcode/Basic select/511. Game Play Analysis I/gpt/GamePlay_Analysis_I_mysql.md
+++ b/SQL/Leetcode/Basic select/511. Game Play Analysis I/gpt/GamePlay_Analysis_I_mysql.md
@@ -1,0 +1,215 @@
+# MySQL 8.0.40
+
+## 0) 前提
+
+- エンジン: **MySQL 8**
+- 並び順: 任意（`ORDER BY` を付けない）
+- `NOT IN` は NULL 罠のため回避
+- 判定は **ID 基準**、表示は仕様どおりの列名と順序
+
+## 1) 問題（原文）
+
+- `Write a solution to find the first login date for each player.`
+- 入力テーブル例: `Activity(player_id, device_id, event_date, games_played)`（`PRIMARY KEY(player_id, event_date)`）
+- 出力仕様: `player_id, first_login`（各 `player_id` の **最初の `event_date`**）
+
+## 2) 最適解（単一クエリ）
+
+> 各プレイヤー内で `event_date` 昇順に順位を振り、最初の 1 件のみ抽出。
+
+```sql
+WITH win AS (
+  SELECT
+    player_id,
+    event_date,
+    ROW_NUMBER() OVER (
+      PARTITION BY player_id
+      ORDER BY event_date ASC
+    ) AS rn
+  FROM Activity
+)
+SELECT
+  player_id,
+  event_date AS first_login
+FROM win
+WHERE rn = 1;
+
+Runtime 611 ms
+Beats 15.03%
+```
+
+- `ROW_NUMBER` は同日の重複が無く（PK 制約あり）安定
+- 返却順は任意のため `ORDER BY` は不要（高速）
+
+## 3) 代替解
+
+> さらにシンプルで速い **集約版**（本問は重複が無いのでこれで十分）。
+
+```sql
+SELECT
+  player_id,
+  MIN(event_date) AS first_login
+FROM Activity
+GROUP BY player_id;
+
+-- Runtime 476 ms
+-- Beats 61.28%
+
+```
+
+※ ウィンドウ関数が不要なケース（「各グループの最小日付」）では `GROUP BY + MIN` が最軽量。
+
+## 4) 要点解説
+
+- **方針**: プレイヤー単位で最初のログイン日を求める
+
+  - ウィンドウ解: 1 行だけ取りたい時に汎用的
+  - 集約解: 純粋に最小日だけでよい時は最速
+
+- **NULL / 重複**:
+
+  - 本テーブルは PK により `(player_id, event_date)` が一意 → 同日重複なし
+  - `event_date` はログイン発生日であり通常 `NULL` 想定なし（もしあれば `WHERE event_date IS NOT NULL` を追加）
+
+- **安定性**: 返却順不問 → `ORDER BY` 省略で I/O を減らす
+
+## 5) 計算量（概算）
+
+- ウィンドウ版: パーティション内ソートが支配的 → **O(N log N)**（インデックス`(player_id, event_date)`で実効コスト低下）
+- 集約版: グループ集約 → **O(N)**～**O(N log N)**（ハッシュ/ツリー実装次第）
+
+## 6) 図解（Mermaid 超保守版）
+
+```mermaid
+flowchart TD
+  A[Activity] --> B[プレイヤー単位で並べる]
+  B --> C[最小日付の行だけ抽出]
+  C --> D[出力 player_id, first_login]
+```
+
+結論から言うと、**この問題はウィンドウ関数を使わずに `GROUP BY + MIN` に寄せ、カバリングになる複合インデックスで“インデックスだけ”の走査に落とし込む**のが最速・最安です。実装と点検ポイントをまとめます。
+
+---
+
+## 推奨クエリ（最短経路）
+
+```sql
+-- 返却順は任意なので ORDER BY なし
+SELECT
+  player_id,
+  MIN(event_date) AS first_login
+FROM Activity
+GROUP BY player_id;
+
+-- Runtime 436 ms
+-- Beats 91.68%
+
+```
+
+### なぜ速い？
+
+- 本問は「各グループの最小値」だけが欲しい＝**集約一発**で済むため、
+  ウィンドウ関数のパーティションソートより軽いケースが多いです。
+- さらに **カバリングインデックス** にできれば、**テーブルアクセスなし**（Index Only Scan）になりやすい。
+
+---
+
+## インデックス設計（超重要）
+
+> すでに PK が `(player_id, event_date)` と明記されているなら、そのままで OK です。
+> もし PK が別構成なら、以下のセカンダリインデックスを追加してください。
+
+```sql
+-- PK が (player_id, event_date) でない環境向け
+CREATE INDEX ix_activity_player_event ON Activity (player_id, event_date);
+```
+
+- クエリが参照する列は `player_id` と `event_date` だけ →
+  `(player_id, event_date)` の**先頭一致**でグループ化＆`MIN(event_date)`が取りやすく、
+  2 列で**完全カバリング**します。
+
+---
+
+## ウィンドウ版しか使っていない場合の改善
+
+CTE ＋`ROW_NUMBER()` 版より、以下のどちらかに替えて計測してみてください。
+
+### A) 集約版（最有力）
+
+```sql
+SELECT player_id, MIN(event_date) AS first_login
+FROM Activity
+GROUP BY player_id;
+```
+
+### B) ウィンドウ簡略版（CTE なし・派生表のみ）
+
+```sql
+SELECT player_id, event_date AS first_login
+FROM (
+  SELECT
+    player_id,
+    event_date,
+    ROW_NUMBER() OVER (PARTITION BY player_id ORDER BY event_date) AS rn
+  FROM Activity
+) t
+WHERE rn = 1;
+
+-- Runtime 469 ms
+-- Beats 67.06%
+
+```
+
+> MySQL 8.0 は非再帰 CTE を多くの場合マージしますが、状況により**実体化**されると余計な I/O が乗ります。
+> 派生表に直すだけでプランが良化することがあります。
+
+---
+
+## 実測・確認手順（再現性のある比較）
+
+1. 統計の更新
+
+```sql
+ANALYZE TABLE Activity;
+```
+
+2. 実行計画の確認
+
+```sql
+EXPLAIN FORMAT=TREE
+SELECT player_id, MIN(event_date) AS first_login
+FROM Activity
+GROUP BY player_id;
+```
+
+- 期待：`using index` / ルースインデックススキャン相当の挙動、**余計なソートが無い**こと
+
+3. 実測（MySQL 8.0.18+）
+
+```sql
+EXPLAIN ANALYZE
+SELECT player_id, MIN(event_date) AS first_login
+FROM Activity
+GROUP BY player_id;
+```
+
+---
+
+## さらに詰めるなら
+
+- **不要列を絶対に投影しない**：`device_id` や `games_played` を出すとカバリングが崩れます。
+- **ORDER BY を付けない**：出力順は任意仕様なのでコスト増の全表ソートを避ける。
+- **大規模運用での恒常最速**：書込みが許せるなら、`player_first_login(player_id PK, first_login)` の**集約テーブル**を持ち、
+  `INSERT ... ON DUPLICATE KEY UPDATE first_login = LEAST(first_login, VALUES(first_login))` で更新。
+  読み出しは O(1) になります。
+
+---
+
+## 目安（期待できる改善）
+
+- ウィンドウ → 集約への置換だけで **~20–50% 改善** が出ることが多いです。
+- もともと PK が `(player_id, event_date)` なら、**Index Only** によってさらに短縮が見込めます。
+- 既に提示の 611ms → 476ms の改善が出ているなら、上記の **集約＋カバリング** を徹底することで、
+  もう一段（環境次第で 2〜3 割）狙える余地があります。
+
+---

--- a/SQL/Leetcode/Basic select/511. Game Play Analysis I/gpt/GamePlay_Analysis_I_pandas.md
+++ b/SQL/Leetcode/Basic select/511. Game Play Analysis I/gpt/GamePlay_Analysis_I_pandas.md
@@ -1,0 +1,211 @@
+# Pandas 2.2.2
+
+## 0) 前提
+
+- 環境: **Python 3.10.15 / pandas 2.2.2**
+- **指定シグネチャ厳守**（関数名・引数名・返却列・順序）
+- I/O 禁止、不要な `print` や `sort_values` 禁止
+
+## 1) 問題（原文）
+
+- `Write a solution to find the first login date for each player.`
+- 入力 DF: `Activity(player_id: int, device_id: int, event_date: date, games_played: int)`
+- 出力: `player_id, first_login`（各 `player_id` について最小の `event_date`）
+
+## 2) 実装（指定シグネチャ厳守）
+
+> 列最小化 → グループ集約（最小日）→ 列名整形。`sort_values` 不要、`groupby.agg(min)` 一発。
+
+```python
+import pandas as pd
+
+def first_login(Activity: pd.DataFrame) -> pd.DataFrame:
+    """
+    Returns:
+        pd.DataFrame: 列名と順序は ['player_id', 'first_login']
+    """
+    # 必要列だけに縮約（カバリング相当）
+    a = Activity[['player_id', 'event_date']]
+
+    # 各 player_id ごとの最小 event_date を算出
+    out = (
+        a.groupby('player_id', as_index=False, observed=True)
+         .agg(first_login=('event_date', 'min'))
+    )
+
+    # 並び順要件は任意のため sort は行わない
+    return out
+
+# Analyze Complexity
+
+# Runtime 299 ms
+# Beats 56.54%
+# Memory 68.25 MB
+# Beats 34.48%
+
+```
+
+### 代替（等価・好みで選択）
+
+- `transform('min')` → `drop_duplicates('player_id')` で取り出す方法（行元を保持したい場合に便利）
+
+```python
+  def first_login(Activity: pd.DataFrame) -> pd.DataFrame:
+      a = Activity[['player_id', 'event_date']].copy()
+      a['first_login'] = a.groupby('player_id')['event_date'].transform('min')
+      return a[['player_id', 'first_login']].drop_duplicates('player_id').reset_index(drop=True)
+
+# Analyze Complexity
+
+# Runtime 264 ms
+# Beats 97.25%
+# Memory 68.60 MB
+# Beats 12.35%
+```
+
+## 3) アルゴリズム説明
+
+- 使用 API
+
+  - `DataFrame.__getitem__`：必要列へ縮約
+  - `groupby(...).agg({'col':'min'})`：グループ最小日を算出
+
+- **NULL / 重複 / 型**
+
+  - `event_date` に `NaT` が混在しても `min` は非 `NaT` を優先（全て `NaT` のグループは `NaT`）
+  - `(player_id, event_date)` が元々一意でも、本解は重複の有無に依らず正しく最小日を返す
+  - `event_date` は `datetime64[ns]` or `datetime64[ns, tz-naive]` 前提（`date` 由来でも `min` 可）
+
+## 4) 計算量（概算）
+
+- `groupby.agg(min)`：**O(N)** ～ **O(N log n_g)**（内部のグループ化実装に依存）
+  メモリはグループキー数に比例
+
+## 5) 図解（Mermaid 超保守版）
+
+```mermaid
+flowchart TD
+  A[入力 データフレーム Activity]
+  B[前処理 列最小化 player_id と event_date]
+  C[グループ集約 各 player_id の最小日]
+  D[出力 player_id, first_login]
+  A --> B
+  B --> C
+  C --> D
+```
+
+さらに詰めるなら、**中間 DataFrame を作らず “列 → 単一リダクション” に直行**し、`groupby` の余計な処理を外すのが定石です。下の置き換えでだいたい **5〜20%** は狙えます（データ分布次第）。
+
+---
+
+## 改善版（最短ホットパス）
+
+```python
+import pandas as pd
+
+def first_login(Activity: pd.DataFrame) -> pd.DataFrame:
+    """
+    Returns:
+        pd.DataFrame: ['player_id', 'first_login']
+    """
+    # 前提: I/O なし、不要な sort_values なし
+    # 1) 直接 SeriesGroupBy.min に当てる（.agg('min') より軽い）
+    # 2) groupby の余計な並べ替えを抑止: sort=False
+    # 3) category 利用時のダミー行回避: observed=True
+    out = (
+        Activity
+        .groupby('player_id', sort=False, observed=True)['event_date']
+        .min()
+        .rename('first_login')
+        .reset_index()
+    )
+    return out
+
+# Analyze Complexity
+
+# Runtime 309 ms
+# Beats 41.94%
+# Memory 67.68 MB
+# Beats 95.52%
+
+```
+
+### 追加の“安価な”微調整（任意）
+
+```python
+def first_login(Activity: pd.DataFrame) -> pd.DataFrame:
+    # 可能なら事前に型を整える（コピー抑制に注意: copy=False）
+    if Activity['player_id'].dtype != 'int32':
+        # ID が 2^31-1 を超えない前提なら downcast
+        Activity = Activity.assign(player_id=Activity['player_id'].astype('int32', copy=False))
+
+    if not pd.api.types.is_datetime64_ns_dtype(Activity['event_date']):
+        Activity = Activity.assign(event_date=pd.to_datetime(Activity['event_date'], utc=False, errors='coerce'))
+
+    return (
+        Activity.groupby('player_id', sort=False, observed=True)['event_date']
+        .min()
+        .rename('first_login')
+        .reset_index()
+    )
+
+# Analyze Complexity
+
+# Runtime 259 ms
+# Beats 98.67%
+# Memory 67.94 MB
+# Beats 75.06%
+
+```
+
+> ポイント
+>
+> - **`.groupby(... )['event_date'].min()`** は **`.agg(min)`** よりオーバーヘッドが小さい。
+> - **`sort=False`** でグループキーの並べ替えを抑止。
+> - **`observed=True`** は `player_id` が `category` の場合に未出現カテゴリを除外（不要計算を消せる）。
+> - `player_id` を **`int32`**（または **`category`**）へ、`event_date` を **`datetime64[ns]`** へ正規化すると、メモリ圧縮と演算器分岐の削減に効きます。
+
+---
+
+## さらに効かせたいときの条件付きテク
+
+- **重複が多い**（同一 `(player_id, event_date)` が大量）なら、前段で列最小化＋ユニーク化が効くことがあります：
+
+  ```python
+  # 重複が顕著な場合のみトレードオフで検討
+  a = Activity[['player_id', 'event_date']].drop_duplicates()
+  out = a.groupby('player_id', sort=False, observed=True)['event_date'].min().rename('first_login').reset_index()
+  ```
+
+  > 重複が少ないと逆効果（drop のコスト分だけ遅くなる）なので要計測。
+
+- **`player_id` がカテゴリとして管理されている**場合は、未使用カテゴリを事前に落とす：
+
+  ```python
+  if pd.api.types.is_categorical_dtype(Activity['player_id']):
+      Activity = Activity.assign(player_id=Activity['player_id'].cat.remove_unused_categories())
+  ```
+
+---
+
+## なぜ速いのか（簡潔版）
+
+- **中間 DF を作らない** → メモリアロケーション＆参照解決が減る
+- **Series 直リダクション** → `GroupBy.min` の C 実装に直行し、`agg` のディスパッチ＆辞書展開を回避
+- **`sort=False`** → グループキーの整列やインデックス再構築を抑える
+- **型の正規化** → 分岐（object 日付や Python `date` → `Timestamp`）を排除しホットパスに乗せる
+
+---
+
+## 計算量（概算）
+
+- `groupby(...).min()`：**O(N)** 〜 **O(N log n_g)**（ハッシュグループ化実装・キー分布に依存）
+  メモリは **ユニーク `player_id` 数** に概ね比例
+
+---
+
+### 期待できる変化の目安
+
+- あなたの 299ms → 264ms の差はまさに **オーバーヘッド削減**で出る領域です。
+- 上の最短ホットパス＋型正規化で、**数％〜十数％** 上積みが出るケースが多いです（特に `object`→`datetime64[ns]` だった場合）。
+- これ以上はデータ分布依存（例：キー数が極端に多い／少ない、重複の偏り）なので、上記の「条件付きテク」を AB 計測して最良を採用してください。

--- a/SQL/Leetcode/Basic select/511. Game Play Analysis I/gpt/GamePlay_Analysis_I_posgres.md
+++ b/SQL/Leetcode/Basic select/511. Game Play Analysis I/gpt/GamePlay_Analysis_I_posgres.md
@@ -1,0 +1,110 @@
+# PostgreSQL 16.6+
+
+## 0) 前提
+
+- エンジン: **PostgreSQL 16.6+**
+- 並び順: 任意
+- `NOT IN` 回避（`EXISTS` / `LEFT JOIN ... IS NULL` を推奨）
+- 判定は ID 基準、表示は仕様どおり
+
+## 1) 問題
+
+- `Write a solution to find the first login date for each player.`
+- 入力: `Activity(player_id int, device_id int, event_date date, games_played int)`
+  ※ `(player_id, event_date)` が一意（PK）
+- 出力: `player_id, first_login`（各 `player_id` について最小の `event_date`）
+
+## 2) 最適解（単一クエリ）
+
+> 各プレイヤー内で `event_date` 昇順に順位を振り、最初の 1 行のみ抽出。
+
+```sql
+WITH win AS (
+  SELECT
+    player_id,
+    event_date,
+    ROW_NUMBER() OVER (
+      PARTITION BY player_id
+      ORDER BY event_date
+    ) AS rn
+  FROM Activity
+)
+SELECT
+  player_id,
+  event_date AS first_login
+FROM win
+WHERE rn = 1;
+
+-- Runtime 490 ms
+-- Beats 75.06%
+
+```
+
+### 代替（LATERAL で上位 1 を抽出）
+
+> グループ（player）ごとに最小日だけ取り出す。大量データで **適切な複合インデックス** があると高速。
+
+```sql
+-- 事前に: CREATE INDEX ON Activity (player_id, event_date);
+SELECT p.player_id, s.event_date AS first_login
+FROM (SELECT DISTINCT player_id FROM Activity) AS p
+JOIN LATERAL (
+  SELECT event_date
+  FROM Activity a
+  WHERE a.player_id = p.player_id
+  ORDER BY event_date
+  LIMIT 1
+) AS s ON TRUE;
+
+-- Runtime 525 ms
+-- Beats 51.62%
+
+```
+
+> 参考: PostgreSQL ではこの問題は **DISTINCT ON** も強力です（インデックス `(player_id, event_date)` と相性抜群）。
+
+```sql
+SELECT DISTINCT ON (player_id)
+  player_id,
+  event_date AS first_login
+FROM Activity
+ORDER BY player_id, event_date;
+
+-- Runtime 465 ms
+-- Beats 98.47%
+
+```
+
+## 3) 要点解説
+
+- ウィンドウ版は可読性が高く汎用（同率処理や k>1 に拡張しやすい）。
+- データ量が大きいほど、`(player_id, event_date)` の複合インデックスが効きます。
+
+  - **DISTINCT ON** / **LATERAL+LIMIT** はインデックス順アクセスで「先頭だけ」取りやすい。
+  - 参照列が `player_id, event_date` のみなら **Index Only Scan** になりうる。
+
+- 並び順は任意なので `ORDER BY` は付けず I/O を削減（上の DISTINCT ON 例は規則上必要）。
+
+## 4) 計算量（概算）
+
+- ウィンドウ処理: **O(Σ n_g log n_g)**
+- LATERAL 上位 1: **O(#player × log n_g)**（インデックス利用時）
+- DISTINCT ON（良いインデックスあり）: ほぼ線形に近い
+
+## 5) 図解（Mermaid 超保守版）
+
+```mermaid
+flowchart TD
+  A[Activity] --> B[プレイヤー内で日付昇順に順位付け]
+  B --> C[先頭1行のみ抽出]
+  C --> D[出力 player_id, first_login]
+```
+
+---
+
+### 実運用の最適化メモ（短縮版）
+
+- 推奨インデックス: `CREATE INDEX ON Activity (player_id, event_date);`
+- プラン確認: `EXPLAIN (ANALYZE, BUFFERS)` でソートや全表走査が残っていないかを点検
+- 超高速読み出しが必要なら、`player_first_login(player_id PRIMARY KEY, first_login date)` の集約テーブルを用意し、
+  `INSERT ... ON CONFLICT ... DO UPDATE SET first_login = LEAST(...)` で漸更新すると O(1) 取得が可能です。


### PR DESCRIPTION
# Pandas 2.2.2

- Redundant as_index=False parameter with named aggregation.

On line 32, as_index=False is unnecessary when using named aggregation syntax (line 33: agg(first_login=...)). Named aggregation automatically returns a DataFrame with reset index. The parameter does not cause an error but adds unnecessary noise.

-    out = (
-        a.groupby('player_id', as_index=False, observed=True)
+    out = (
+        a.groupby('player_id', observed=True)
          .agg(first_login=('event_date', 'min'))
     )

- Unnecessary .copy() in alternative implementation.

On line 54, the .copy() call after slicing is not needed. In pandas, column selection already returns a view-like copy in most cases, and the subsequent drop_duplicates() will create its own copy anyway. Removing it saves an allocation with minimal functional change.

-      a = Activity[['player_id', 'event_date']].copy()
+      a = Activity[['player_id', 'event_date']]
       a['first_login'] = a.groupby('player_id')['event_date'].transform('min')

# PostgreSQL 16.6+

- LATERAL JOIN solution is sound; verify index creation in practice.

The LATERAL approach correctly applies LIMIT 1 per player to fetch only the earliest event_date. The prerequisite index on (player_id, event_date) is well-motivated for query optimization. However, note that the index creation command (line 48) should ideally include an index name for production clarity and future management. Current performance (51.62%) suggests this approach may underperform without proper indexing or on smaller datasets where index overhead outweighs benefit.

-- Recommended: Add an explicit index name for production use
CREATE INDEX idx_activity_player_event ON Activity (player_id, event_date);

- Optimization guidance is practical; aggregation table suggestion trades off correctness concerns.

The index recommendations and EXPLAIN analysis tips are excellent and actionable. However, the aggregation table suggestion (player_first_login maintained via INSERT ... ON CONFLICT ... DO UPDATE SET) warrants a clarification: this approach assumes first_login is immutable once set, which is true for first login but may introduce maintenance complexity if player history is ever corrected or backfilled. This is a micro-optimization best suited for read-heavy, append-only scenarios.

Consider adding a brief note:

**Aggregation table caveat**: This approach assumes `first_login` is append-only. If historical corrections are needed, maintain the aggregation table via scheduled batch jobs rather than trigger-based updates.

- ORDER BY rationale is explained but could benefit from explicit PostgreSQL semantics.

The note "(上の DISTINCT ON 例は規則上必要)" (the DISTINCT ON example above requires it per spec) correctly clarifies why ORDER BY appears in the DISTINCT ON solution but not in the final output of the window function. For non-Japanese readers or those unfamiliar with PostgreSQL's DISTINCT ON semantics, a brief inline explanation of why the order matters for correctness (not just aesthetics) would help.

Consider adding a brief clarification:

**Note on DISTINCT ON and ORDER BY**: PostgreSQL's `DISTINCT ON` returns the *first* row of each group as determined by the `ORDER BY` clause. The ordering here is mandatory for correctness, not optional.
