### PR TITLE
Fix README_react.html SVG viewBox and Prism JS SRI hashes

### DIFF
--- a/JavaScript/2626. Array Reduce Transformation/Claude Code Sonnet 4.5 extended/README_react.html
+++ b/JavaScript/2626. Array Reduce Transformation/Claude Code Sonnet 4.5 extended/README_react.html
@@ -338,7 +338,7 @@ function reduce(nums: number[], fn: Fn, init: number): number {
                 </h2>
                 <div class="mt-[20px] overflow-x-auto">
                     <svg
-                        viewBox="0 0 840 620"
+                        viewBox="0 0 840 700"
                         style="max-width: 100%; height: auto; color: #333"
                         role="img"
                         aria-label="Array Reduce Transformation flowchart"
@@ -891,12 +891,12 @@ function reduce(nums: number[], fn: Fn, init: number): number {
         ></script>
         <script
             src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js"
-            integrity="sha384-nUkTNLI8COlMCRJ0FHIdX76If83145OTCLUx4gQyfnO0gGeO/sD9czGEUBxtkcUv"
+            integrity="sha384-6QJu8apxMmB9TiPVWzYKF5pRgKcz7snO0/QU+MrWmgBLECQjoa6erxX2VQ5t41Jd"
             crossorigin="anonymous"
         ></script>
         <script
             src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/toolbar/prism-toolbar.min.js"
-            integrity="sha384-EUzJ34/1CCeefTGUKLgvA5Z/vYIwi+Jyu8aAaCfFDxfwZ3Xs3OfkkIeegsLRM11e"
+            integrity="sha384-jC1G68eGEXJpPwMDNqyIUQsQlcUCdCU+a7GGuoV4TUZvM1gLYTMJUDvqBnxtZLWA"
             crossorigin="anonymous"
         ></script>
         <script


### PR DESCRIPTION
SVG ViewBox: Increased height back to 700 to prevent clipping.
SRI Hashes: Updated hashes for Prism JS plugins to match the correct JS files.